### PR TITLE
Add user profile editing functionality and form

### DIFF
--- a/templates/warehouse/edit_profile.html
+++ b/templates/warehouse/edit_profile.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+
+{% block title %}Edycja profilu - KSP{% endblock %}
+
+{% block content %}
+<div class="row justify-content-center">
+    <div class="col-md-6">
+        <div class="card shadow">
+            <div class="card-header bg-primary text-white">
+                <h5 class="mb-0">Edycja profilu użytkownika</h5>
+            </div>
+            <div class="card-body">
+                <form method="post" novalidate>
+                    {% csrf_token %}
+                    
+                    {% if form.non_field_errors %}
+                        <div class="alert alert-danger">
+                            {% for error in form.non_field_errors %}
+                                {{ error }}
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                    
+                    <div class="mb-3">
+                        <label for="{{ form.username.id_for_label }}" class="form-label">Nazwa użytkownika:</label>
+                        {{ form.username }}
+                        {% if form.username.errors %}
+                            <div class="text-danger">
+                                {% for error in form.username.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="{{ form.email.id_for_label }}" class="form-label">Adres e-mail:</label>
+                        {{ form.email }}
+                        {% if form.email.errors %}
+                            <div class="text-danger">
+                                {% for error in form.email.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="{{ form.first_name.id_for_label }}" class="form-label">Imię:</label>
+                        {{ form.first_name }}
+                        {% if form.first_name.errors %}
+                            <div class="text-danger">
+                                {% for error in form.first_name.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+                    
+                    <div class="mb-3">
+                        <label for="{{ form.last_name.id_for_label }}" class="form-label">Nazwisko:</label>
+                        {{ form.last_name }}
+                        {% if form.last_name.errors %}
+                            <div class="text-danger">
+                                {% for error in form.last_name.errors %}
+                                    {{ error }}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+                    
+                    <div class="d-grid gap-2 mt-4">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fas fa-save"></i> Zapisz zmiany
+                        </button>
+                        <a href="{% url 'warehouse:profile' %}" class="btn btn-secondary">
+                            <i class="fas fa-times"></i> Anuluj
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/warehouse/profile.html
+++ b/templates/warehouse/profile.html
@@ -46,6 +46,9 @@
                 </div>
                 
                 <div class="d-grid gap-2 mt-4">
+                    <a href="{% url 'warehouse:edit_profile' %}" class="btn btn-primary mb-2">
+                        <i class="fas fa-user-edit"></i> Edytuj profil
+                    </a>
                     <a href="{% url 'warehouse:change_password' %}" class="btn btn-primary">
                         <i class="fas fa-key"></i> Zmień hasło
                     </a>

--- a/warehouse/forms.py
+++ b/warehouse/forms.py
@@ -259,3 +259,36 @@ class CustomUserCreationForm(UserCreationForm):
         if email and User.objects.filter(email__iexact=email).exists():
             raise forms.ValidationError('Użytkownik o tym adresie email już istnieje.')
         return email
+
+
+class UserProfileForm(forms.ModelForm):
+    """Form for editing user profile information"""
+
+    class Meta:
+        model = User
+        fields = ('username', 'email', 'first_name', 'last_name')
+        widgets = {
+            'username': forms.TextInput(attrs={'class': 'form-control'}),
+            'email': forms.EmailInput(attrs={'class': 'form-control'}),
+            'first_name': forms.TextInput(attrs={'class': 'form-control'}),
+            'last_name': forms.TextInput(attrs={'class': 'form-control'}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Make fields that might be null required in the form
+        self.fields['email'].required = True
+
+    def clean_username(self):
+        username = self.cleaned_data.get('username')
+        # Check if username exists but isn't the current user's username
+        if User.objects.filter(username__iexact=username).exclude(pk=self.instance.pk).exists():
+            raise forms.ValidationError('Użytkownik o tej nazwie już istnieje.')
+        return username
+
+    def clean_email(self):
+        email = self.cleaned_data.get('email')
+        # Check if email exists but isn't the current user's email
+        if email and User.objects.filter(email__iexact=email).exclude(pk=self.instance.pk).exists():
+            raise forms.ValidationError('Użytkownik o tym adresie email już istnieje.')
+        return email

--- a/warehouse/urls.py
+++ b/warehouse/urls.py
@@ -20,7 +20,7 @@ from warehouse.views.ajax import (
     autocomplete_items, autocomplete_manufacturers, autocomplete_users
 )
 from warehouse.views.account import (
-    profile, change_password, custom_logout
+    profile, edit_profile, change_password, custom_logout
 )
 from warehouse.views.history import history_list
 
@@ -91,6 +91,7 @@ urlpatterns = [
     path('ajax/bulk-remove-items/', ajax_bulk_remove_items, name='ajax_bulk_remove_items'),
     # User profile and password management
     path('profile/', profile, name='profile'),
+    path('profile/edit/', edit_profile, name='edit_profile'),
     path('profile/change-password/', change_password, name='change_password'),
     path('logout/', custom_logout, name='custom_logout'),
     # Low stock view

--- a/warehouse/views/__init__.py
+++ b/warehouse/views/__init__.py
@@ -39,7 +39,7 @@ from warehouse.views.ajax import (
 
 # Import account views
 from warehouse.views.account import (
-    profile, change_password, custom_logout, register
+    profile, edit_profile, change_password, custom_logout, register
 )
 
 # Define __all__ to explicitly specify what's exported from this package
@@ -69,5 +69,5 @@ __all__ = [
     'autocomplete_items', 'autocomplete_manufacturers',
     
     # Account management
-    'profile', 'change_password', 'custom_logout', 'register',
+    'profile', 'edit_profile', 'change_password', 'custom_logout', 'register',
 ]

--- a/warehouse/views/account.py
+++ b/warehouse/views/account.py
@@ -7,13 +7,30 @@ from django.contrib.auth import update_session_auth_hash, logout
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib import messages
 
-from warehouse.forms import CustomUserCreationForm
+from warehouse.forms import CustomUserCreationForm, UserProfileForm
 
 
 @login_required
 def profile(request):
     """User profile view"""
     return render(request, 'warehouse/profile.html')
+
+
+@login_required
+def edit_profile(request):
+    """Edit user profile view"""
+    if request.method == 'POST':
+        form = UserProfileForm(request.POST, instance=request.user)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Twój profil został pomyślnie zaktualizowany!')
+            return redirect('warehouse:profile')
+        else:
+            messages.error(request, 'Proszę poprawić błędy w formularzu.')
+    else:
+        form = UserProfileForm(instance=request.user)
+    
+    return render(request, 'warehouse/edit_profile.html', {'form': form})
 
 
 @login_required


### PR DESCRIPTION
This pull request introduces a new feature allowing users to edit their profiles. It includes changes to templates, forms, views, and routing to support this functionality.

### New Feature: User Profile Editing

#### Templates
* Added a new template `edit_profile.html` to provide a user interface for editing profile details, including fields for username, email, first name, and last name. The form includes validation error handling and buttons for saving or canceling changes.
* Updated `profile.html` to include a button linking to the new "Edit Profile" page.

#### Forms
* Created a new form class `UserProfileForm` in `warehouse/forms.py` for validating and rendering user profile fields. It includes custom validation to ensure unique usernames and email addresses.

#### Views
* Added a new view function `edit_profile` in `warehouse/views/account.py` to handle GET and POST requests for editing user profiles. It uses the `UserProfileForm` and provides success or error messages based on form submission outcomes.

#### Routing
* Updated `warehouse/urls.py` to include a new route `/profile/edit/` that maps to the `edit_profile` view.
* Adjusted imports in `warehouse/views/__init__.py` to include the new `edit_profile` view. [[1]](diffhunk://#diff-705f379e86f9d5bc886d21ca7733700be5c5faa411da1077d8c27bff78dc6740L42-R42) [[2]](diffhunk://#diff-705f379e86f9d5bc886d21ca7733700be5c5faa411da1077d8c27bff78dc6740L72-R72)